### PR TITLE
chore: add aditional root url response

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -36,13 +36,26 @@ from service.models import InventoryItem, Condition, DataValidationError
 ######################################################################
 
 
+@app.route("/")
+def index():
+    """Root URL response with service URL and available resources"""
+    app.logger.info("Request for root URL")
+    return (
+        jsonify(
+            url=url_for("index", _external=True),
+            resources={"inventory": url_for("inventory_index", _external=True)},
+        ),
+        status.HTTP_200_OK,
+    )
+
+
 ######################################################################
 # GET INDEX
 ######################################################################
 @app.route("/inventory")
-def index():
-    """Root URL response"""
-    # app.logger.info("Request for root URL")
+def inventory_index():
+    """Inventory Root URL response"""
+    app.logger.info("Request for inventory URL")
     return (
         jsonify(
             name="Inventory RESTful Service",

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -85,6 +85,15 @@ class TestInventoryService(TestCase):
             "The inventory service tracks product stock levels and conditions.",
         )
 
+    def test_root_url(self):
+        """It should call the root URL and return service url and resources"""
+        resp = self.client.get("/")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertIn("url", data)
+        self.assertIn("resources", data)
+        self.assertIn("inventory", data["resources"])
+
     # ----------------------------------------------------------
     # TEST CREATE
     # ----------------------------------------------------------


### PR DESCRIPTION
I think there was some confusion about the root URL requirement

We have an endpoint for 

```
GET /inventory/
```

But the root URL is actually

```
GET /
```

This PR adds an additional route for the root URL