### PR TITLE
feat: implement decrement inventory endpoint

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -336,3 +336,66 @@ def update_inventory_item(public_id):
 
     app.logger.info("inventory item with ID: %d updated.", inventory_item.id)
     return jsonify(inventory_item.serialize()), status.HTTP_200_OK
+
+
+######################################################################
+# DECREMENT INVENTORY QUANTITY
+######################################################################
+@app.route("/inventory/items/<string:public_id>/decrement", methods=["POST"])
+def decrement_inventory_item(public_id):
+    """
+    Decrement the quantity of an inventory item
+    This endpoint will decrement the quantity of an item by a specific amount
+    """
+    app.logger.info("Request to Decrement inventory item with id [%s]", public_id)
+    check_content_type("application/json")
+
+    # Find Inventory Item by public id
+    inventory_item = InventoryItem.find_by_public_id(public_id)
+    if not inventory_item:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Inventory item with id '{public_id}' was not found.",
+        )
+
+    data = request.get_json()
+    if data is None or "amount" not in data:
+        return (
+            jsonify(
+                status=status.HTTP_400_BAD_REQUEST,
+                error="Bad Request",
+                message="Missing 'amount' in request body",
+            ),
+            status.HTTP_400_BAD_REQUEST,
+        )
+
+    amount = data.get("amount")
+
+    # Verify amount is non-negative
+    if not isinstance(amount, int) or amount < 0:
+        return (
+            jsonify(
+                status=status.HTTP_400_BAD_REQUEST,
+                error="Bad Request",
+                message="quantity must be non-negative",
+            ),
+            status.HTTP_400_BAD_REQUEST,
+        )
+
+    # Check storage
+    if inventory_item.quantity < amount:
+        return (
+            jsonify(
+                status=status.HTTP_400_BAD_REQUEST,
+                error="Bad Request",
+                message="INSUFFICIENT INVENTORY",
+            ),
+            status.HTTP_400_BAD_REQUEST,
+        )
+
+    # Decrement
+    inventory_item.quantity -= amount
+    inventory_item.update()
+
+    app.logger.info("Inventory item [%s] decremented by [%d]", public_id, amount)
+    return jsonify(inventory_item.serialize()), status.HTTP_200_OK

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -529,3 +529,54 @@ class TestInventoryService(TestCase):
         response = self.client.get(BASE_URL)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.content_type, "application/json")
+
+    # ----------------------------------------------------------
+    # TEST DECREMENT
+    # ----------------------------------------------------------
+    def test_decrement_inventory_success(self):
+        """It should successfully decrement inventory quantity"""
+        test_item = InventoryItemFactory(quantity=10)
+        test_item.create()
+
+        payload = {"amount": 2, "orderId": "order_123"}
+        response = self.client.post(
+            f"{BASE_URL}/{test_item.public_id}/decrement", json=payload
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        new_data = response.get_json()
+        self.assertEqual(new_data["quantity"], 8)
+
+    def test_decrement_negative_amount(self):
+        """It should reject a negative decrement amount"""
+        test_item = InventoryItemFactory(quantity=10)
+        test_item.create()
+
+        payload = {"amount": -5, "orderId": "order_123"}
+        response = self.client.post(
+            f"{BASE_URL}/{test_item.public_id}/decrement", json=payload
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("quantity must be non-negative", response.get_json()["message"])
+
+    def test_decrement_insufficient_inventory(self):
+        """It should return 400 if inventory is insufficient"""
+        test_item = InventoryItemFactory(quantity=5)
+        test_item.create()
+
+        payload = {"amount": 10, "orderId": "order_123"}
+        response = self.client.post(
+            f"{BASE_URL}/{test_item.public_id}/decrement", json=payload
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.get_json()["message"], "INSUFFICIENT INVENTORY")
+
+    def test_decrement_item_not_found(self):
+        """It should return 404 when decrementing a non-existent item"""
+        payload = {"amount": 2, "orderId": "order_123"}
+        response = self.client.post(
+            f"{BASE_URL}/non-existent-id/decrement", json=payload
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
Closes #10 
Add the functionality to decrement the quantity of a specific inventory item. This endpoint is essential for the order fulfillment process, allowing consuming services to reduce stock levels without needing to manage the current inventory state themselves.

**Logic Implementation**: 
* Validates that the `amount` is a non-negative integer.
* Verifies if the inventory item exists (returns 404 if not found).
* Checks if there is sufficient stock to perform the decrement.
* Updates the inventory quantity in the database and returns the updated item.

### Acceptance Criteria Verified
* Successfully decrement inventory quantity: Returns `200 OK` with updated quantity.
* Reject negative quantity: Returns `400 BAD REQUEST` when `amount < 0`.
* Inventory quantity is not sufficient: Returns `400 BAD REQUEST` with error message `"INSUFFICIENT INVENTORY"`.
* Inventory item not found: Returns `404 NOT FOUND` for invalid item IDs.