### PR TITLE
feat: add production Dockerfile and replace image name placeholder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM quay.io/rofrano/python:3.12-slim
+
+# Set up the Python production environment
+WORKDIR /app
+COPY Pipfile Pipfile.lock ./
+RUN python -m pip install --upgrade pip pipenv && \
+    pipenv install --system --deploy
+
+# Copy the application contents
+COPY wsgi.py .
+COPY service/ ./service/
+
+# Switch to a non-root user and set file ownership
+RUN useradd --uid 1001 flask && \
+    chown -R flask /app
+USER flask
+
+# Expose any ports the app is expecting in the environment
+ENV FLASK_APP="wsgi:app"
+ENV PORT=8080
+EXPOSE $PORT
+
+ENV GUNICORN_BIND=0.0.0.0:$PORT
+ENTRYPOINT ["gunicorn"]
+CMD ["--log-level=info", "wsgi:app"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # These can be overidden with env vars.
 REGISTRY ?= cluster-registry:5000
-IMAGE_NAME ?= petshop
+IMAGE_NAME ?= inventory
 IMAGE_TAG ?= 1.0
 IMAGE ?= $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 PLATFORM ?= "linux/amd64,linux/arm64"


### PR DESCRIPTION
Closes #62 
Closes #55 

- Add production Dockerfile (using lab as reference)
- Use `inventory` for `IMAGE_NAME` in `Makefile`

You can verify:
```
make cluster
make build
make push
```

Note: `make push` might not work on your machine. 

You can use 
```
docker tag cluster-registry:5000/inventory:1.0 localhost:5000/inventory:1.0                                                                                                                                                                                                    
docker push localhost:5000/inventory:1.0
```
As a workaround for now.