### PR TITLE
feat: add health check endpoint for Kubernetes probes

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -50,6 +50,15 @@ def index():
 
 
 ######################################################################
+# HEALTH CHECK
+######################################################################
+@app.route("/health")
+def health_check():
+    """Health check endpoint for Kubernetes probes"""
+    return jsonify(status="OK"), status.HTTP_200_OK
+
+
+######################################################################
 # LIST ALL INVENTORY ITEMS
 ######################################################################
 @app.route("/inventory", methods=["GET"])

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -84,6 +84,16 @@ class TestInventoryService(TestCase):
         self.assertIn("inventory", data["resources"])
 
     # ----------------------------------------------------------
+    # TEST HEALTH CHECK
+    # ----------------------------------------------------------
+    def test_health_check(self):
+        """It should return 200 OK on health check"""
+        response = self.client.get("/health")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertEqual(data["status"], "OK")
+
+    # ----------------------------------------------------------
     # TEST CREATE
     # ----------------------------------------------------------
     def test_create_inventory_item(self):


### PR DESCRIPTION
Closes #31

- Add `GET /health` endpoint returning `{"status": "OK"}` with 200
- Kubernetes will use this as liveness and readiness probe
- Add unit test for the health check endpoint