### PR TITLE
fix: validate product_id is not empty on create

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -151,6 +151,17 @@ def create_inventory_items():
             status.HTTP_400_BAD_REQUEST,
         )
 
+    # Validate product_id is not empty
+    if not inventory_item.product_id or not inventory_item.product_id.strip():
+        return (
+            jsonify(
+                status=status.HTTP_400_BAD_REQUEST,
+                error="Bad Request",
+                message="Invalid InventoryItem: product_id must not be empty",
+            ),
+            status.HTTP_400_BAD_REQUEST,
+        )
+
     # Prevent duplicate (product_id + condition) -> 409 CONFLICT
     # query the database for the inventory item
     existing = InventoryItem.query.filter_by(

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -155,6 +155,26 @@ class TestInventoryService(TestCase):
         self.assertIn("message", data)
         self.assertIn("product_id", data["message"].lower())
 
+    def test_create_inventory_item_empty_product_id(self):
+        """It should return 400 when product_id is empty string"""
+        test_item = InventoryItemFactory.build()
+        payload = test_item.serialize()
+        payload["product_id"] = ""
+        response = self.client.post(BASE_URL, json=payload)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = response.get_json()
+        self.assertIn("product_id", data["message"].lower())
+
+    def test_create_inventory_item_negative_quantity(self):
+        """It should reject request with negative quantity and return 400"""
+        test_item = InventoryItemFactory.build()
+        payload = test_item.serialize()
+        payload["quantity"] = -5
+        response = self.client.post(BASE_URL, json=payload)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = response.get_json()
+        self.assertIn("quantity", data["message"].lower())
+
     def test_create_inventory_item_no_content_type_returns_415(self):
         """It should return 415 when Content-Type header is missing"""
         response = self.client.post(


### PR DESCRIPTION
Closes #70

## Summary
Fix bug where inventory items could be created with an empty string as product_id.

## Changes
- `service/routes.py` — Add validation after deserialize to reject empty or whitespace-only product_id with 400 Bad Request
- `tests/test_routes.py` — Add test for empty product_id (400) and negative quantity (400) on create

## Verification
```
make test
```
All tests pass, 95%+ coverage.