### PR TITLE
Feat: UI - Update an Inventory Item

### DIFF
--- a/features/inventory.feature
+++ b/features/inventory.feature
@@ -125,88 +125,36 @@ Scenario: Read an Inventory Item that does not exist
     Then I should see the message "was not found"
 
 # update
-# Scenario: Update an Inventory Item
-#     When I visit the "Home Page"
-#     And I set the "Product Id" to "PROD001"
-#     And I press the "Search" button
-#     Then I should see the message "Success"
-#     And I should see "PROD001" in the "Product Id" field
-#     And I should see "100" in the "Quantity" field
-#     When I set the "Quantity" to "200"
-#     And I press the "Update" button
-#     Then I should see the message "Success"
-#     When I copy the "Id" field
-#     And I press the "Clear" button
-#     And I paste the "Id" field
-#     And I press the "Retrieve" button 
-#     Then I should see the message "Success"
-#     And I should see "200" in the "Quantity" field
+Scenario: Update an Inventory Item via inline edit
+    When I visit the "Home Page"
+    And I set the "Product Id" to "PROD001"
+    And I press the "Search" button
+    Then I should see the message "Success"
+    And I should see "PROD001" in the results
+    When I click the "Edit" button in the results table
+    And I set the row "Quantity" field to "200"
+    And I press the "Save" button in the results table
+    Then I should see the message "Success"
+    And I should see "200" in the results
 
-# Scenario: Update an Inventory Item with invalid quantity
-#     When I visit the "Home Page"
-#     And I set the "Product Id" to "PROD001"
-#     And I press the "Search" button
-#     Then I should see the message "Success"
-#     When I set the "Quantity" to "-10"
-#     And I press the "Update" button
-#     Then I should see the message "quantity must be non-negative"
+Scenario: Update an Inventory Item with invalid quantity
+    When I visit the "Home Page"
+    And I set the "Product Id" to "PROD001"
+    And I press the "Search" button
+    Then I should see the message "Success"
+    When I click the "Edit" button in the results table
+    And I set the row "Quantity" field to "-10"
+    And I press the "Save" button in the results table
+    Then I should see an error for the row "Quantity" field
 
-# Scenario: Update an Inventory Item that does not exist
-#     When I visit the "Home Page"
-#     And I set the "Id" to "00000000-0000-0000-0000-000000000000"
-#     And I set the "Product Id" to "PROD001"
-#     And I set the "Quantity" to "200"
-#     And I press the "Update" button
-#     Then I should see the message "was not found"
-
-# Scenario: Update an Inventory Item restock level and restock amount
-#     When I visit the "Home Page"
-#     And I set the "Product Id" to "PROD001"
-#     And I press the "Search" button
-#     Then I should see the message "Success"
-#     When I set the "Restock Level" to "30"
-#     And I set the "Restock Amount" to "60"
-#     And I press the "Update" button
-#     Then I should see the message "Success"
-#     When I copy the "Id" field
-#     And I press the "Clear" button
-#     And I paste the "Id" field
-#     And I press the "Retrieve" button 
-#     Then I should see the message "Success"
-#     And I should see "30" in the "Restock Level" field
-#     And I should see "60" in the "Restock Amount" field
-
-# Scenario: Update an Inventory Item condition
-#     When I visit the "Home Page"
-#     And I set the "Product Id" to "PROD001"
-#     And I press the "Search" button
-#     Then I should see the message "Success"
-#     When I select "Used" in the "Condition" dropdown
-#     And I press the "Update" button
-#     Then I should see the message "Success"
-#     When I copy the "Id" field
-#     And I press the "Clear" button
-#     And I paste the "Id" field
-#     And I press the "Retrieve" button 
-#     Then I should see the message "Success"
-#     And I should see "Used" in the "Condition" dropdown
-
-# Scenario: Update multiple fields of an Inventory Item
-#     When I visit the "Home Page"
-#     And I set the "Product Id" to "PROD002"
-#     And I select "Open Box" in the "Condition" dropdown
-#     And I press the "Search" button
-#     Then I should see the message "Success"
-#     When I set the "Quantity" to "50"
-#     And I set the "Restock Level" to "15"
-#     And I set the "Restock Amount" to "30"
-#     And I press the "Update" button
-#     Then I should see the message "Success"
-#     When I copy the "Id" field
-#     And I press the "Clear" button
-#     And I paste the "Id" field
-#     And I press the "Retrieve" button 
-#     Then I should see the message "Success"
-#     And I should see "50" in the "Quantity" field
-#     And I should see "15" in the "Restock Level" field
-#     And I should see "30" in the "Restock Amount" field
+Scenario: Cancel editing an Inventory Item
+    When I visit the "Home Page"
+    And I set the "Product Id" to "PROD001"
+    And I press the "Search" button
+    Then I should see the message "Success"
+    And I should see "100" in the results
+    When I click the "Edit" button in the results table
+    And I set the row "Quantity" field to "999"
+    And I press the "Cancel" button in the results table
+    Then I should see "100" in the results
+    And I should not see "999" in the results

--- a/features/inventory.feature
+++ b/features/inventory.feature
@@ -123,3 +123,90 @@ Scenario: Read an Inventory Item that does not exist
     And I set the "Id" to "00000000-0000-0000-0000-000000000000"
     And I press the "Retrieve" button
     Then I should see the message "was not found"
+
+# update
+# Scenario: Update an Inventory Item
+#     When I visit the "Home Page"
+#     And I set the "Product Id" to "PROD001"
+#     And I press the "Search" button
+#     Then I should see the message "Success"
+#     And I should see "PROD001" in the "Product Id" field
+#     And I should see "100" in the "Quantity" field
+#     When I set the "Quantity" to "200"
+#     And I press the "Update" button
+#     Then I should see the message "Success"
+#     When I copy the "Id" field
+#     And I press the "Clear" button
+#     And I paste the "Id" field
+#     And I press the "Retrieve" button 
+#     Then I should see the message "Success"
+#     And I should see "200" in the "Quantity" field
+
+# Scenario: Update an Inventory Item with invalid quantity
+#     When I visit the "Home Page"
+#     And I set the "Product Id" to "PROD001"
+#     And I press the "Search" button
+#     Then I should see the message "Success"
+#     When I set the "Quantity" to "-10"
+#     And I press the "Update" button
+#     Then I should see the message "quantity must be non-negative"
+
+# Scenario: Update an Inventory Item that does not exist
+#     When I visit the "Home Page"
+#     And I set the "Id" to "00000000-0000-0000-0000-000000000000"
+#     And I set the "Product Id" to "PROD001"
+#     And I set the "Quantity" to "200"
+#     And I press the "Update" button
+#     Then I should see the message "was not found"
+
+# Scenario: Update an Inventory Item restock level and restock amount
+#     When I visit the "Home Page"
+#     And I set the "Product Id" to "PROD001"
+#     And I press the "Search" button
+#     Then I should see the message "Success"
+#     When I set the "Restock Level" to "30"
+#     And I set the "Restock Amount" to "60"
+#     And I press the "Update" button
+#     Then I should see the message "Success"
+#     When I copy the "Id" field
+#     And I press the "Clear" button
+#     And I paste the "Id" field
+#     And I press the "Retrieve" button 
+#     Then I should see the message "Success"
+#     And I should see "30" in the "Restock Level" field
+#     And I should see "60" in the "Restock Amount" field
+
+# Scenario: Update an Inventory Item condition
+#     When I visit the "Home Page"
+#     And I set the "Product Id" to "PROD001"
+#     And I press the "Search" button
+#     Then I should see the message "Success"
+#     When I select "Used" in the "Condition" dropdown
+#     And I press the "Update" button
+#     Then I should see the message "Success"
+#     When I copy the "Id" field
+#     And I press the "Clear" button
+#     And I paste the "Id" field
+#     And I press the "Retrieve" button 
+#     Then I should see the message "Success"
+#     And I should see "Used" in the "Condition" dropdown
+
+# Scenario: Update multiple fields of an Inventory Item
+#     When I visit the "Home Page"
+#     And I set the "Product Id" to "PROD002"
+#     And I select "Open Box" in the "Condition" dropdown
+#     And I press the "Search" button
+#     Then I should see the message "Success"
+#     When I set the "Quantity" to "50"
+#     And I set the "Restock Level" to "15"
+#     And I set the "Restock Amount" to "30"
+#     And I press the "Update" button
+#     Then I should see the message "Success"
+#     When I copy the "Id" field
+#     And I press the "Clear" button
+#     And I paste the "Id" field
+#     And I press the "Retrieve" button 
+#     Then I should see the message "Success"
+#     And I should see "50" in the "Quantity" field
+#     And I should see "15" in the "Restock Level" field
+#     And I should see "30" in the "Restock Amount" field

--- a/features/steps/web_steps.py
+++ b/features/steps/web_steps.py
@@ -34,6 +34,7 @@ from selenium.webdriver.support import expected_conditions
 
 ID_PREFIX = "item_"
 
+
 def save_screenshot(context: Any, filename: str) -> None:
     """Takes a snapshot of the web page for debugging and validation
 
@@ -190,3 +191,61 @@ def step_impl(context: Any, element_name: str, text_string: str) -> None:
     )
     element.clear()
     element.send_keys(text_string)
+
+
+##################################################################
+# Steps for inline editing in the search results table
+##################################################################
+
+
+@when('I click the "Edit" button in the results table')
+def step_impl(context: Any) -> None:
+    button = WebDriverWait(context.driver, context.wait_seconds).until(
+        expected_conditions.element_to_be_clickable(
+            (By.CSS_SELECTOR, "#search_results .edit-row-btn")
+        )
+    )
+    button.click()
+
+
+@when('I set the row "{field_name}" field to "{text_string}"')
+def step_impl(context: Any, field_name: str, text_string: str) -> None:
+    field_id = field_name.lower().replace(" ", "_")
+    element = WebDriverWait(context.driver, context.wait_seconds).until(
+        expected_conditions.presence_of_element_located(
+            (By.CSS_SELECTOR, f'#search_results [data-field="{field_id}"]')
+        )
+    )
+    element.clear()
+    element.send_keys(text_string)
+
+
+@when('I press the "Save" button in the results table')
+def step_impl(context: Any) -> None:
+    button = WebDriverWait(context.driver, context.wait_seconds).until(
+        expected_conditions.element_to_be_clickable(
+            (By.CSS_SELECTOR, "#search_results .save-row-btn")
+        )
+    )
+    button.click()
+
+
+@when('I press the "Cancel" button in the results table')
+def step_impl(context: Any) -> None:
+    button = WebDriverWait(context.driver, context.wait_seconds).until(
+        expected_conditions.element_to_be_clickable(
+            (By.CSS_SELECTOR, "#search_results .cancel-row-btn")
+        )
+    )
+    button.click()
+
+
+@then('I should see an error for the row "{field_name}" field')
+def step_impl(context: Any, field_name: str) -> None:
+    field_id = field_name.lower().replace(" ", "_")
+    error_div = WebDriverWait(context.driver, context.wait_seconds).until(
+        expected_conditions.presence_of_element_located(
+            (By.CSS_SELECTOR, f"#search_results .err-{field_id}")
+        )
+    )
+    assert error_div.text != ""

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -109,6 +109,7 @@
             <th class="col-md-2">Quantity</th>
             <th class="col-md-2">Restock Level</th>
             <th class="col-md-2">Restock Amount</th>
+            <th class="col-md-2">Update</th>
           </tr>
           </thead>
         </table>

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -91,7 +91,6 @@
                 <button type="submit" class="btn btn-primary" id="search-btn">Search</button>
                 <button type="submit" class="btn btn-primary" id="clear-btn">Clear</button>
                 <button type="submit" class="btn btn-success" id="create-btn">Create</button>
-                <button type="submit" class="btn btn-warning" id="update-btn">Update</button>
               </div>
             </div>
           </div> <!-- form horizontal -->

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -70,47 +70,6 @@ $(function () {
 
 
     // ****************************************
-    // Update an Inventory Item
-    // ****************************************
-
-    $("#update-btn").click(function () {
-
-        let item_id = $("#item_id").val();
-        let product_id = $("#item_product_id").val();
-        let condition = $("#item_condition").val();
-        let quantity = parseInt($("#item_quantity").val());
-        let restock_level = parseInt($("#item_restock_level").val());
-        let restock_amount = parseInt($("#item_restock_amount").val());
-
-        let data = {
-            "product_id": product_id,
-            "condition": condition,
-            "quantity": quantity,
-            "restock_level": restock_level,
-            "restock_amount": restock_amount
-        };
-
-        $("#flash_message").empty();
-
-        let ajax = $.ajax({
-                type: "PUT",
-                url: `/inventory/${item_id}`,
-                contentType: "application/json",
-                data: JSON.stringify(data)
-            })
-
-        ajax.done(function(res){
-            update_form_data(res)
-            flash_message("Success")
-        });
-
-        ajax.fail(function(res){
-            flash_message(res.responseJSON.message)
-        });
-
-    });
-
-    // ****************************************
     // Retrieve an Inventory Item
     // ****************************************
 
@@ -178,7 +137,7 @@ $(function () {
     });
 
     // ****************************************
-    // Search for Inventory Items
+    // Search for Inventory Items in results table
     // ****************************************
 
     $("#search-btn").click(function () {

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -271,17 +271,17 @@ $(function () {
         };
         $row.data("orig", orig);
 
-        cells.eq(1).html(`<input type="text" class="form-control input-sm" value="${orig.product_id}">`);
+        cells.eq(1).html(`<input type="text" class="form-control input-sm" data-field="product_id" value="${orig.product_id}">`);
         cells.eq(2).html(
-            `<select class="form-control input-sm">` +
+            `<select class="form-control input-sm" data-field="condition">` +
             `<option value="NEW" ${orig.condition === "NEW" ? "selected" : ""}>New</option>` +
             `<option value="OPEN_BOX" ${orig.condition === "OPEN_BOX" ? "selected" : ""}>Open Box</option>` +
             `<option value="USED" ${orig.condition === "USED" ? "selected" : ""}>Used</option>` +
             `</select>`
         );
-        cells.eq(3).html(`<input type="number" class="form-control input-sm" value="${orig.quantity}"><div class="text-danger small err-quantity"></div>`);
-        cells.eq(4).html(`<input type="number" class="form-control input-sm" value="${orig.restock_level}"><div class="text-danger small err-restock_level"></div>`);
-        cells.eq(5).html(`<input type="number" class="form-control input-sm" value="${orig.restock_amount}"><div class="text-danger small err-restock_amount"></div>`);
+        cells.eq(3).html(`<input type="number" class="form-control input-sm" data-field="quantity" value="${orig.quantity}"><div class="text-danger small err-quantity"></div>`);
+        cells.eq(4).html(`<input type="number" class="form-control input-sm" data-field="restock_level" value="${orig.restock_level}"><div class="text-danger small err-restock_level"></div>`);
+        cells.eq(5).html(`<input type="number" class="form-control input-sm" data-field="restock_amount" value="${orig.restock_amount}"><div class="text-danger small err-restock_amount"></div>`);
         cells.eq(6).html(
             `<button class="btn btn-xs btn-success save-row-btn">Save</button> ` +
             `<button class="btn btn-xs btn-default cancel-row-btn">Cancel</button>`

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -219,11 +219,20 @@ $(function () {
             table += '<th class="col-md-2">Quantity</th>'
             table += '<th class="col-md-2">Restock Level</th>'
             table += '<th class="col-md-2">Restock Amount</th>'
+            table += '<th class="col-md-2">Update</th>'
             table += '</tr></thead><tbody>'
             let firstItem = "";
             for(let i = 0; i < res.length; i++) {
                 let item = res[i];
-                table +=  `<tr id="row_${i}"><td>${item.public_id}</td><td>${item.product_id}</td><td>${item.condition}</td><td>${item.quantity}</td><td>${item.restock_level}</td><td>${item.restock_amount}</td></tr>`;
+                table += `<tr id="row_${i}" data-public-id="${item.public_id}">` +
+                    `<td>${item.public_id}</td>` +
+                    `<td>${item.product_id}</td>` +
+                    `<td>${item.condition}</td>` +
+                    `<td>${item.quantity}</td>` +
+                    `<td>${item.restock_level}</td>` +
+                    `<td>${item.restock_amount}</td>` +
+                    `<td><button class="btn btn-xs btn-warning edit-row-btn">Edit</button></td>` +
+                    `</tr>`;
                 if (i == 0) {
                     firstItem = item;
                 }
@@ -245,4 +254,121 @@ $(function () {
 
     });
 
+    // ****************************************
+    // Edit button in search results row
+    // ****************************************
+
+    $("#search_results").on("click", ".edit-row-btn", function () {
+        let $row = $(this).closest("tr");
+        let cells = $row.find("td");
+
+        let orig = {
+            product_id: cells.eq(1).text(),
+            condition: cells.eq(2).text(),
+            quantity: cells.eq(3).text(),
+            restock_level: cells.eq(4).text(),
+            restock_amount: cells.eq(5).text()
+        };
+        $row.data("orig", orig);
+
+        cells.eq(1).html(`<input type="text" class="form-control input-sm" value="${orig.product_id}">`);
+        cells.eq(2).html(
+            `<select class="form-control input-sm">` +
+            `<option value="NEW" ${orig.condition === "NEW" ? "selected" : ""}>New</option>` +
+            `<option value="OPEN_BOX" ${orig.condition === "OPEN_BOX" ? "selected" : ""}>Open Box</option>` +
+            `<option value="USED" ${orig.condition === "USED" ? "selected" : ""}>Used</option>` +
+            `</select>`
+        );
+        cells.eq(3).html(`<input type="number" class="form-control input-sm" value="${orig.quantity}"><div class="text-danger small err-quantity"></div>`);
+        cells.eq(4).html(`<input type="number" class="form-control input-sm" value="${orig.restock_level}"><div class="text-danger small err-restock_level"></div>`);
+        cells.eq(5).html(`<input type="number" class="form-control input-sm" value="${orig.restock_amount}"><div class="text-danger small err-restock_amount"></div>`);
+        cells.eq(6).html(
+            `<button class="btn btn-xs btn-success save-row-btn">Save</button> ` +
+            `<button class="btn btn-xs btn-default cancel-row-btn">Cancel</button>`
+        );
+    });
+
+    // ****************************************
+    // Cancel button in search results row
+    // ****************************************
+
+    $("#search_results").on("click", ".cancel-row-btn", function () {
+        let $row = $(this).closest("tr");
+        let orig = $row.data("orig");
+        let cells = $row.find("td");
+
+        cells.eq(1).text(orig.product_id);
+        cells.eq(2).text(orig.condition);
+        cells.eq(3).text(orig.quantity);
+        cells.eq(4).text(orig.restock_level);
+        cells.eq(5).text(orig.restock_amount);
+        cells.eq(6).html(`<button class="btn btn-xs btn-warning edit-row-btn">Edit</button>`);
+    });
+
+    // ****************************************
+    // Save button in search results row
+    // ****************************************
+
+    $("#search_results").on("click", ".save-row-btn", function () {
+        let $row = $(this).closest("tr");
+        let cells = $row.find("td");
+        let public_id = $row.data("public-id");
+
+        let product_id = cells.eq(1).find("input").val();
+        let condition = cells.eq(2).find("select").val();
+        let quantity = parseInt(cells.eq(3).find("input").val());
+        let restock_level = parseInt(cells.eq(4).find("input").val());
+        let restock_amount = parseInt(cells.eq(5).find("input").val());
+
+        // Client-side validation
+        let valid = true;
+        $row.find(".err-quantity").text("");
+        $row.find(".err-restock_level").text("");
+        $row.find(".err-restock_amount").text("");
+
+        if (isNaN(quantity) || quantity < 0) {
+            $row.find(".err-quantity").text("Must be a non-negative integer");
+            valid = false;
+        }
+        if (isNaN(restock_level) || restock_level < 0) {
+            $row.find(".err-restock_level").text("Must be a non-negative integer");
+            valid = false;
+        }
+        if (isNaN(restock_amount) || restock_amount < 0) {
+            $row.find(".err-restock_amount").text("Must be a non-negative integer");
+            valid = false;
+        }
+        if (!valid) return;
+
+        let data = {
+            "product_id": product_id,
+            "condition": condition,
+            "quantity": quantity,
+            "restock_level": restock_level,
+            "restock_amount": restock_amount
+        };
+
+        $("#flash_message").empty();
+
+        let ajax = $.ajax({
+            type: "PUT",
+            url: `/inventory/${public_id}`,
+            contentType: "application/json",
+            data: JSON.stringify(data)
+        });
+
+        ajax.done(function (res) {
+            cells.eq(1).text(res.product_id);
+            cells.eq(2).text(res.condition);
+            cells.eq(3).text(res.quantity);
+            cells.eq(4).text(res.restock_level);
+            cells.eq(5).text(res.restock_amount);
+            cells.eq(6).html(`<button class="btn btn-xs btn-warning edit-row-btn">Edit</button>`);
+            flash_message("Success");
+        });
+
+        ajax.fail(function (res) {
+            flash_message(res.responseJSON.message);
+        });
+    });
 })


### PR DESCRIPTION
 - Removed the top-form "Update" button and its #update-btn click handler from the UI

  - Added an "Edit" button to each row in the search results table
  - Clicking "Edit" turns the row into an inline editable form (inputs for product_id, quantity, restock_level,
  restock_amount; select for condition)
  - "Save" validates inputs client-side (non-negative integers), calls PUT /inventory/:public_id, and updates the row on
   success or displays the API error message on failure
  - "Cancel" restores all original values without making any API call
  
  - Added new step definitions in web_steps.py and BDD scenarios
  - `make bdd` passes all scenarios