### PR TITLE
feat: add k8s deploy, ingress, and service manifests

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory
+  labels:
+    app: inventory
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0%
+      maxUnavailable: 50%
+  selector:
+    matchLabels:
+      app: inventory
+  template:
+    metadata:
+      labels:
+        app: inventory
+    spec:
+      restartPolicy: Always
+      containers:
+      - name: inventory
+        image: cluster-registry:5000/inventory:1.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        env:
+          - name: RETRY_COUNT
+            value: "10"
+          - name: DATABASE_URI
+            valueFrom:
+              secretKeyRef:
+                name: postgres-creds
+                key: database_uri
+        readinessProbe:
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          httpGet:
+            path: /health
+            port: 8080
+        resources:
+          limits:
+            cpu: "0.50"
+            memory: "128Mi"
+          requests:
+            cpu: "0.25"
+            memory: "64Mi"

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: inventory
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: inventory
+            port:
+              number: 8080

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: inventory
+spec:
+  selector:
+    app: inventory
+  type: ClusterIP
+  internalTrafficPolicy: Local
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080


### PR DESCRIPTION
Closes #54
Adds the three Kubernetes manifests needed to deploy the inventory microservice to a local K3D cluster.  These values were mostly copied over from the k8s lab.                                  
                                                                                                                                                                                                                                                                            
  k8s/deployment.yaml
  - Deploys 1 replica of cluster-registry:5000/inventory:1.0
  - Rolling update strategy (50% max unavailable)                                                                                             
  - DATABASE_URI injected from the existing postgres-creds secret
  - Readiness probe on GET /health (port 8080)                                                                                                
  - Resource limits: 0.50 CPU / 128Mi memory 
                                                                                                                                              
  k8s/service.yaml                                                                                                                            
  - ClusterIP service exposing the deployment on port 8080                                                                                    
                                                                                                                                              
  k8s/ingress.yaml
  - Routes all external traffic (/) to the inventory service                                                                                  
  - Works with the load balancer port mapping (8080:80) configured in make cluster                                                            
   
  How to test                                                                                                                                 
  Launch dev container

Run
```
  make cluster   # create K3D cluster                                                                                                         
  make build     # build image
  make push      # push to cluster registry
  make deploy    # apply all manifests (postgres + inventory)                                                                                 

  kubectl get pods                      # verify Running state                                                                                
  curl http://localhost:8080/health     # expect {"status": "OK"}
```