### PR TITLE
feat: add restock action endpoint with UI and BDD scenario

### DIFF
--- a/features/inventory.feature
+++ b/features/inventory.feature
@@ -315,3 +315,19 @@ Scenario: Update restock_level and restock_amount via inline edit
     Then I should see the message "Success"
     And I should see "35" in the results
     And I should see "45" in the results
+
+Scenario: Restock an Inventory Item
+    When I visit the "Home Page"
+    And I set the "Product Id" to "PROD003"
+    And I press the "Search" button
+    Then I should see the message "Success"
+    And I should see "PROD003" in the results
+    When I copy the "Id" field
+    And I press the "Retrieve" button
+    Then I should see the message "Success"
+    And I should see "PROD003" in the "Product Id" field
+    And I should see "5" in the "Quantity" field
+    And I should see "40" in the "Restock Amount" field
+    When I press the "Restock" button
+    Then I should see the message "Success"
+    And I should see "45" in the "Quantity" field

--- a/service/routes.py
+++ b/service/routes.py
@@ -419,3 +419,30 @@ def decrement_inventory_item(public_id):
 
     app.logger.info("Inventory item [%s] decremented by [%d]", public_id, amount)
     return jsonify(inventory_item.serialize()), status.HTTP_200_OK
+
+
+######################################################################
+# RESTOCK INVENTORY ITEM
+######################################################################
+@app.route("/inventory/<string:public_id>/restock", methods=["POST"])
+def restock_inventory_item(public_id):
+    """
+    Restock an inventory item
+    This endpoint will increase the quantity of an item by its restock_amount
+    """
+    app.logger.info("Request to Restock inventory item with id [%s]", public_id)
+
+    # Find Inventory Item by public id
+    inventory_item = InventoryItem.find_by_public_id(public_id)
+    if not inventory_item:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Inventory item with id '{public_id}' was not found.",
+        )
+
+    # Restock: add restock_amount to quantity
+    inventory_item.quantity += inventory_item.restock_amount
+    inventory_item.update()
+
+    app.logger.info("Inventory item [%s] restocked by [%d]", public_id, inventory_item.restock_amount)
+    return jsonify(inventory_item.serialize()), status.HTTP_200_OK

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -127,6 +127,7 @@
                 <button type="submit" class="btn btn-success" id="create-btn">Create</button>
                 <button type="submit" class="btn btn-warning" id="update-btn">Update</button>
                 <button type="submit" class="btn btn-info" id="list_all-btn">List All</button>
+                <button type="submit" class="btn btn-success" id="restock-btn">Restock</button>
               </div>
             </div>
           </div> <!-- form horizontal -->

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -413,6 +413,33 @@ $(function () {
   });
 
   // ****************************************
+  // Restock an Inventory Item
+  // ****************************************
+
+    $("#restock-btn").click(function () {
+
+        let item_id = $("#item_id").val();
+
+        $("#flash_message").empty();
+
+        let ajax = $.ajax({
+            type: "POST",
+            url: `/inventory/${item_id}/restock`,
+            contentType: "application/json",
+            data: '{}'
+        })
+
+        ajax.done(function(res){
+            update_form_data(res)
+            flash_message("Success")
+        });
+
+        ajax.fail(function(res){
+            flash_message(res.responseJSON.message)
+        });
+    });
+
+  // ****************************************
   // List all Inventory Items
   // ****************************************
   $("#list_all-btn").click(function () {

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -722,3 +722,28 @@ class TestInventoryService(TestCase):
             f"{BASE_URL}/non-existent-id/decrement", json=payload
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    # ----------------------------------------------------------
+    # TEST RESTOCK
+    # ----------------------------------------------------------
+    def test_restock_inventory_success(self):
+        """It should successfully restock an inventory item"""
+        test_item = InventoryItemFactory(quantity=5, restock_level=10, restock_amount=40)
+        test_item.create()
+
+        response = self.client.post(
+            f"{BASE_URL}/{test_item.public_id}/restock",
+            content_type="application/json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        new_data = response.get_json()
+        self.assertEqual(new_data["quantity"], 45)
+
+    def test_restock_item_not_found(self):
+        """It should return 404 when restocking a non-existent item"""
+        response = self.client.post(
+            f"{BASE_URL}/non-existent-id/restock",
+            content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
Closes #43

## Summary
Add a Restock action that increases an inventory item's quantity by its preset restock_amount. Includes backend route, UI button, and BDD scenario.

## Changes

### Backend
- `service/routes.py` — New `POST /inventory/<public_id>/restock` route, adds restock_amount to quantity
- `tests/test_routes.py` — 2 new unit tests: restock success (quantity 5→45) and item not found (404)

### UI
- `service/static/index.html` — Added Restock button
- `service/static/js/rest_api.js` — Added Restock click handler that POSTs to the restock endpoint

### BDD
- `features/inventory.feature` — Added Restock scenario: Search → Retrieve → Restock → verify quantity increased

## Verification
```
make test        # all unit tests pass
honcho start &
make bdd         # 30 scenarios, 290 steps pass
```