### PR TITLE
feat: add tekton lint and test tasks running in parallel after clone

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -45,3 +45,38 @@ spec:
           value: "false"
         - name: USER_HOME
           value: /home/git
+
+    - name: lint
+      taskRef:
+        resolver: cluster
+        params:
+          - name: kind
+            value: task
+          - name: name
+            value: pylint
+          - name: namespace
+            value: openshift-pipelines
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+      params:
+        - name: path
+          value: service
+      runAfter:
+        - git-clone
+
+    - name: test
+      taskRef:
+        resolver: cluster
+        params:
+          - name: kind
+            value: task
+          - name: name
+            value: pytest-env
+          - name: namespace
+            value: openshift-pipelines
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+      runAfter:
+        - git-clone

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -48,14 +48,7 @@ spec:
 
     - name: lint
       taskRef:
-        resolver: cluster
-        params:
-          - name: kind
-            value: task
-          - name: name
-            value: pylint
-          - name: namespace
-            value: openshift-pipelines
+        name: pylint
       workspaces:
         - name: source
           workspace: pipeline-workspace
@@ -67,14 +60,7 @@ spec:
 
     - name: test
       taskRef:
-        resolver: cluster
-        params:
-          - name: kind
-            value: task
-          - name: name
-            value: pytest-env
-          - name: namespace
-            value: openshift-pipelines
+        name: pytest-env
       workspaces:
         - name: source
           workspace: pipeline-workspace

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -1,0 +1,142 @@
+# These are custom tasks that are not on Tekton Hub
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: pylint
+  labels:
+    app.kubernetes.io/version: "0.4"
+  annotations:
+    tekton.dev/categories: Code Quality
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: python, pylint, poetry
+    tekton.dev/displayName: "pylint"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+spec:
+  workspaces:
+    - name: source
+      description: The workspace with the source code.
+  description: >-
+    Use to run pylint on the provided input source. 
+    If Poetry or Pipenv is being used it will detect 
+    the poetry.lock and Pipfile file and install using them.
+  params:
+    - name: image
+      description: The container image with pylint
+      default: quay.io/rofrano/python:3.12-slim
+    - name: path
+      description: The path to the module which should be analyzed by pylint
+      default: "."
+      type: string
+    - name: args
+      description: The arguments to pass to the pylint CLI.
+      type: array
+      default: []
+    - name: requirements-file
+      description: The name of the requirements file inside the source location
+      default: "requirements.txt"
+  steps:
+    - name: pylint
+      image: $(params.image)
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/bin/bash
+        set -e
+        export PATH=$PATH:$HOME/.local/bin:
+
+        echo "***** Installing dependencies *****"
+        if [ -e "poetry.lock" ]; then
+          echo "Found poetry.lock file: using poetry ..."
+          python -m pip install --upgrade pip poetry
+          poetry config virtualenvs.create false
+          poetry install
+        elif [ -e "Pipfile" ]; then
+          echo "Found Pipfile file: using pipenv ..."
+          python -m pip install --upgrade pip pipenv
+          pipenv install --system --dev
+        elif [ -n "$(params.requirements-file)" ] && [ -e "$(params.requirements-file)" ]; then
+          python -m pip install --user -r "$(params.requirements-file)"
+        fi
+
+        # Make sure pylint is installed
+        python -m pip install pylint
+
+        echo "***** Running Linting *****"
+        pylint $@ "$(params.path)"
+      args:
+        - "$(params.args)"
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: pytest-env
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: Testing
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: python, pytest
+    tekton.dev/displayName: "pytest tests"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le"
+spec:
+  workspaces:
+    - name: source
+  description: >-
+    This task can be used to perform unit tests with pytest.
+    It supports both requirements.txt, Pipfile, & poetry.lock files.
+
+    It also has the ability to create an environment variable
+    that is sourced from a Secret. This allows you to define
+    credentials that can be used to connect to a test database.
+  params:
+    - name: pytest-args
+      description: The arguments to pass to the pytest CLI.
+      type: array
+      default: []
+    - name: secret-name
+      description: The name of the secret containing a database_uri key
+      type: string
+      default: "postgres-creds"
+    - name: secret-key
+      description: The name of the key that contains the database uri
+      type: string
+      default: "database_uri"
+  steps:
+    - name: pytest
+      image: quay.io/rofrano/python:3.12-slim
+      workingDir: $(workspaces.source.path)
+      env:
+       - name: DATABASE_URI
+         valueFrom:
+           secretKeyRef:
+             name: $(params.secret-name)
+             key: $(params.secret-key)
+      script: |
+        #!/bin/bash
+        set -e
+        export PATH=$PATH:$HOME/.local/bin:
+
+        echo "***** Installing dependencies *****"
+        if [ -e "poetry.lock" ]; then
+          echo "Found poetry.lock file: using poetry ..."
+          python -m pip install --upgrade pip poetry
+          poetry config virtualenvs.create false
+          poetry install
+        elif [ -e "Pipfile" ]; then
+          echo "Found Pipfile file: using pipenv ..."
+          python -m pip install --upgrade pip pipenv
+          pipenv install --system --dev
+        elif -e "requirements.txt" ]; then
+          python -m pip install --user -r requirements.txt
+        fi
+
+        # Make sure pylint is installed
+        python -m pip install pytest
+
+        echo "***** Running Tests *****"
+        pytest --version
+        pytest
+      args:
+        - "$(params.pytest-args)"
+


### PR DESCRIPTION
Closes #91

## Summary
Add custom Tekton lint and test tasks that run in parallel after the git-clone task in the CD pipeline.

## Changes
- `.tekton/tasks.yaml` — Added `pylint` and `pytest-env` custom task definitions (from `lab-openshift`)
- `.tekton/pipeline.yaml` — Added `lint` and `test` pipeline tasks, both `runAfter: [git-clone]` so they execute in parallel

## Verification
```
make test        # 75 passed, 97% coverage (no regression)
make lint        # clean (10/10)
YAML validation  # both files valid
```