### PR TITLE
fix: add PGDATA env var to postgres statefulset for OpenShift compatibility

### DIFF
--- a/k8s/postgres/statefulset.yaml
+++ b/k8s/postgres/statefulset.yaml
@@ -30,6 +30,8 @@ spec:
                 secretKeyRef:
                   name: postgres-creds
                   key: password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
           volumeMounts:
           - name: postgres-storage
             mountPath: /var/lib/postgresql/data


### PR DESCRIPTION
Closes #87

## Summary
Add `PGDATA` environment variable to the PostgreSQL StatefulSet so that it initializes correctly on OpenShift. Without this, the pod enters CrashLoopBackOff because the PVC mount point contains a `lost+found` directory that conflicts with PostgreSQL's data initialization.

## Changes
- `k8s/postgres/statefulset.yaml` — Added `PGDATA: /var/lib/postgresql/data/pgdata` env var to write data into a subdirectory instead of the mount root

## Verification
```
oc get pods -l app=postgres
NAME         READY   STATUS    RESTARTS   AGE
postgres-0   1/1     Running   0          23s

oc get svc postgres
NAME       TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
postgres   ClusterIP   172.30.125.156   <none>        5432/TCP   21h
```