### PR TITLE
fix: resolve BDD race condition in insufficient inventory step

### DIFF
--- a/features/steps/web_steps.py
+++ b/features/steps/web_steps.py
@@ -347,10 +347,8 @@ def step_impl(context, field):
 @then("I should see an error message indicating insufficient inventory")
 def step_impl(context):
     found = WebDriverWait(context.driver, context.wait_seconds).until(
-        expected_conditions.presence_of_element_located((By.ID, "flash_message"))
+        expected_conditions.text_to_be_present_in_element(
+            (By.ID, "flash_message"), "INSUFFICIENT"
+        )
     )
-    text = found.text.lower()
-    assert any(
-        word in text
-        for word in ["insufficient", "not enough", "lower than", "less than"]
-    )
+    assert found


### PR DESCRIPTION
## Summary
Fix a race condition in the BDD step for the "Insufficient inventory" scenario that caused CI to fail after #103 merged.

## Changes
- `features/steps/web_steps.py` — Changed `presence_of_element_located` to `text_to_be_present_in_element` in the insufficient inventory step, so it waits for the flash message text to appear before asserting

## Verification
```
make bdd
1 feature passed, 0 failed, 0 skipped
34 scenarios passed, 0 failed, 0 skipped
328 steps passed, 0 failed, 0 skipped
Took 0min 19.808s
```