### PR TITLE
feat: add tekton behave task for bdd testing against deployment

### DIFF
--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -183,3 +183,64 @@ spec:
         echo "***** Waiting for rollout *****"
         kubectl rollout status deployment/$(params.app-name)
 
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: behave
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: Testing
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: python, bdd, behave
+    tekton.dev/displayName: "bdd tests"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  workspaces:
+    - name: source
+  description: >-
+    This task can be used to perform bdd tests with behave.
+  params:
+    - name: base-url
+      description: The url of the application to test
+      type: string
+    - name: wait-seconds
+      description: The number of seconds to wait for a reply
+      type: string
+      default: "60"
+    - name: driver
+      description: The web driver to use (chrome or firefox)
+      type: string
+      default: "chrome"
+  steps:
+    - name: behave
+      image: quay.io/rofrano/pipeline-selenium
+      workingDir: $(workspaces.source.path)
+      env:
+       - name: BASE_URL
+         value: $(params.base-url)
+       - name: WAIT_SECONDS
+         value: $(params.wait-seconds)
+       - name: DRIVER
+         value: $(params.driver)
+      script: |
+        #!/bin/bash
+        set -e
+        export PATH=$PATH:$HOME/.local/bin:
+
+        echo "***** Installing dependencies *****"
+        if [ -e "poetry.lock" ]; then
+          echo "Found poetry.lock file: using poetry"
+          python -m pip install poetry poetry-plugin-export
+          poetry export --with=dev -f requirements.txt --output requirements.txt
+        elif [ -e "Pipfile" ]; then
+          echo "Found Pipfile file: using pipenv ..."
+          python -m pip install --upgrade pip pipenv
+          pipenv requirements --dev > requirements.txt
+        fi
+        python -m pip install --user -r requirements.txt
+
+        echo "***** Running Tests *****"
+        behave
+


### PR DESCRIPTION
Closes #45

## Summary
Add a custom Tekton `behave` task that runs BDD tests against the deployed inventory service on OpenShift. The task takes a `base-url` parameter pointing at the deployed route and exposes it as the `BASE_URL` env var so Behave drives the service only through its web UI.

## Changes
- `.tekton/tasks.yaml` — Added `behave` custom task definition (from `lab-openshift`) with `base-url`, `wait-seconds`, and `driver` params; uses `quay.io/rofrano/pipeline-selenium` image

## Verification
```
oc apply -f .tekton/tasks.yaml
task.tekton.dev/pylint configured
task.tekton.dev/pytest-env configured
task.tekton.dev/behave created
```