### PR TITLE
feat: add tekton triggers and event listener

### DIFF
--- a/.tekton/events/event_listener.yaml
+++ b/.tekton/events/event_listener.yaml
@@ -1,0 +1,8 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: cd-listener
+spec:
+  serviceAccountName: pipeline
+  triggers:
+    - triggerRef: cd-trigger

--- a/.tekton/events/route.yaml
+++ b/.tekton/events/route.yaml
@@ -1,0 +1,15 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: el-cd-listener
+  labels:
+    app: el-cd-listener
+spec:
+  to:
+    kind: Service
+    name: el-cd-listener
+  port:
+    targetPort: http-listener
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/.tekton/events/trigger.yaml
+++ b/.tekton/events/trigger.yaml
@@ -1,0 +1,16 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: cd-trigger
+spec:
+  serviceAccountName: pipeline
+  interceptors:
+    - ref:
+        name: cel
+      params:
+        - name: filter
+          value: "body.ref == 'refs/heads/master'"
+  bindings:
+    - ref: cd-binding
+  template:
+    ref: cd-template

--- a/.tekton/events/trigger_binding.yaml
+++ b/.tekton/events/trigger_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerBinding
+metadata:
+  name: cd-binding
+spec:
+  params:
+  - name: git-repo-url
+    value: $(body.repository.html_url)
+  - name: git-repo-name
+    value: $(body.repository.name)
+  - name: git-revision
+    value: $(body.head_commit.id)

--- a/.tekton/events/trigger_template.yaml
+++ b/.tekton/events/trigger_template.yaml
@@ -1,0 +1,35 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: cd-template
+spec:
+  params:
+  - name: git-repo-url
+    description: The git repository url
+  - name: git-revision
+    description: The git revision
+  - name: git-repo-name
+    description: The name of the deployment to be created / patched
+
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      generateName: cd-pipeline-$(tt.params.git-repo-name)-
+    spec:
+      serviceAccountName: pipeline
+      pipelineRef:
+        name: inventory-cd-pipeline
+      params:
+      - name: APP_NAME
+        value: $(tt.params.git-repo-name)
+      - name: GIT_REPO
+        value: $(tt.params.git-repo-url)
+      - name: GIT_REF
+        value: $(tt.params.git-revision)
+      - name: APP_IMAGE
+        value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(tt.params.git-repo-name):$(tt.params.git-revision)
+      workspaces:
+      - name: pipeline-workspace
+        persistentVolumeClaim:
+          claimName: pipeline-pvc


### PR DESCRIPTION
Closes #44 

Adds a GitHub webhook integration that automatically triggers the inventory-cd-pipeline on every push to master.
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  - EventListener (cd-listener) — a Tekton service that receives incoming GitHub webhook POST requests                                                                                                                                                                                                                                                                                        
  - Route (el-cd-listener) — exposes the EventListener externally over HTTPS with edge TLS termination
  - Trigger — filters events using a CEL interceptor (body.ref == 'refs/heads/master'), ignoring pushes to other branches                                                                                                                                                                                                                                                                     
  - TriggerBinding — extracts GIT_REPO and GIT_REF from the GitHub webhook payload and passes them as pipeline params                                                                                                                                                                                                                                                                         
  - TriggerTemplate — creates a PipelineRun when the trigger fires, wiring the extracted params into the pipeline                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                              
 **How to apply**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
 oc apply -f .tekton/events/

**Test**:
You can test this in your own cluster by manually POSTing to the webhook url:

First, find the URL with:
```
oc get route el-cd-listener
```

Then fire a `curl request`:

```
curl -X POST \
  <URL of WEBHOOK> \
  -H 'Content-Type: application/json' \
  -d '{
    "ref": "refs/heads/master",
    "repository": {
      "html_url": "https://github.com/CSCI-GA-2820-SP26-003/inventory",
      "name": "inventory"
    },
    "head_commit": {
      "id": "e69eb942568b83a51a2f9943302e41472f6a6ab7"
    }
  }'
```

I have added my cluster's EL webhook to this repo. Pipeline should run on a merge to `master`