### PR TITLE
chore: add manual deploy script and update readme

### DIFF
--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -127,7 +127,7 @@ spec:
           echo "Found Pipfile file: using pipenv ..."
           python -m pip install --upgrade pip pipenv
           pipenv install --system --dev
-        elif -e "requirements.txt" ]; then
+        elif [ -e "requirements.txt" ]; then
           python -m pip install --user -r requirements.txt
         fi
 

--- a/README.md
+++ b/README.md
@@ -14,20 +14,6 @@ The Inventory service is a RESTful API that tracks product stock levels and cond
 - [Docker](https://www.docker.com/)
 - [VS Code](https://code.visualstudio.com/) with the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension
 
-### Manual Setup
-
-You can also clone this repository and then copy and paste the starter code into your project repo folder on your local computer. Be careful not to copy over your own `README.md` file so be selective in what you copy.
-
-There are 4 hidden files that you will need to copy manually if you use the Mac Finder or Windows Explorer to copy files from this folder into your repo folder.
-
-These should be copied using a bash shell as follows:
-
-```bash
-    cp .gitignore  ../<your_repo_folder>/
-    cp .flaskenv ../<your_repo_folder>/
-    cp .gitattributes ../<your_repo_folder>/
-```
-
 ### Getting Started
 
 1. Clone the repository and open it in VS Code.
@@ -47,48 +33,148 @@ make run
 
 The service will be available at `http://localhost:8080`.
 
+Interactive API documentation (Swagger UI) is at `http://localhost:8080/apidocs`.
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DATABASE_URI` | PostgreSQL connection string | set via `postgres-creds` secret in k8s |
+| `FLASK_RUN_PORT` | Port the Flask dev server listens on | `8080` |
+
+Copy `dot-env-example` to `.env` to set `FLASK_APP` locally if needed.
+
 ## Running Tests
+
+### Unit Tests
 
 ```bash
 make test
 ```
 
-This runs the full test suite with `pytest` and enforces a minimum coverage threshold of 95%.
+Runs the full test suite with `pytest` and enforces a minimum coverage threshold of 95%.
 
-To lint the code:
+### Linting
 
 ```bash
 make lint
 ```
 
+Runs `flake8` and `pylint` against `service/` and `tests/`.
+
+### BDD / Integration Tests
+
+```bash
+make bdd
+```
+
+Runs the Behave feature suite against a running instance of the service. The service must already be started (`make run`) before running BDD tests locally. In CI and in the Tekton pipeline these run against the deployed service.
+
+## Continuous Integration
+
+The GitHub Actions workflow (`.github/workflows/ci.yml`) runs on every push and pull request to `master`. It:
+
+1. Starts a PostgreSQL 15 service container
+2. Installs Python dependencies via `pipenv`
+3. Starts the service and checks `/api/health`
+4. Runs `flake8` and `pylint`
+5. Runs `pytest` with coverage reporting to Codecov
+6. Runs the Behave BDD suite with a headless Chrome driver
+
+## Deployment
+
+### OpenShift / Tekton CD Pipeline
+
+The production deployment runs on OpenShift via a Tekton `inventory-cd-pipeline`. The pipeline performs:
+
+1. **git-clone** — checks out the repository
+2. **lint** — runs `pylint` against `service/`
+3. **test** — runs `pytest` (lint and test run in parallel)
+4. **buildah** — builds and pushes the container image to the OpenShift internal registry
+5. **deploy** — applies k8s manifests and rolls out the new image
+6. **bdd** — runs Behave tests against the live deployment URL
+
+#### Automatic Deploys (Webhook)
+
+Merging to `master` triggers a webhook that fires the `cd-listener` EventListener, which starts a pipeline run automatically via the Tekton trigger template.
+
+#### Manual Deploy
+
+Use `scripts/deploy.sh` to apply all manifests and trigger the pipeline manually:
+
+```bash
+bash scripts/deploy.sh
+```
+
+The script will:
+
+- Verify `oc` and `tkn` CLIs are installed
+- Check that you are logged in to OpenShift (exits with an error if not — run `oc login <cluster-url>` first)
+- Print the current OpenShift user and project
+- Apply PostgreSQL manifests (`k8s/postgres/`)
+- Apply Tekton manifests (workspace, tasks, pipeline, event listener)
+- Apply the application Route (`k8s/route.yaml`)
+- Wait up to 120 s for PostgreSQL to be ready
+- Prompt for a branch or commit SHA to deploy (press **Enter** to use the default: `master`)
+- Start the pipeline and stream logs live
+- Print a pipeline run summary on completion
+
+**Prerequisites:** you must be logged in to the OpenShift cluster before running the script.
+
+```bash
+oc login <cluster-url>
+oc project <your-namespace>
+bash scripts/deploy.sh
+```
+
+### Local Kubernetes (K3D)
+
+To deploy on a local K3D cluster:
+
+```bash
+make cluster      # create a K3D cluster with a local registry
+make deploy       # apply k8s/ manifests with kubectl
+```
+
 ## API Reference
 
-All endpoints are under the base path `/inventory`.
+The service mounts all REST endpoints under the `/api` prefix. Interactive docs are at `/apidocs`.
 
-### Inventory Items
+### Endpoints
 
 | Method | URL | Description |
 |--------|-----|-------------|
-| `GET` | `/inventory` | List all inventory items (ordered by id) |
-| `GET` | `/inventory/<public_id>` | Retrieve a single inventory item |
-| `POST` | `/inventory` | Create a new inventory item |
-| `PUT` | `/inventory/<public_id>` | Update an existing inventory item |
-| `DELETE` | `/inventory/<public_id>` | Delete an inventory item |
-| `POST` | `/inventory/<public_id>/decrement` | Decrement the quantity of an inventory item |
+| `GET` | `/` | Serves the Selenium/UI testing front end |
+| `GET` | `/api/health` | Health check (used by k8s readiness probe) |
+| `GET` | `/api/inventory` | List all inventory items (supports filters) |
+| `GET` | `/api/inventory/<public_id>` | Retrieve a single inventory item |
+| `POST` | `/api/inventory` | Create a new inventory item |
+| `PUT` | `/api/inventory/<public_id>` | Update an existing inventory item |
+| `DELETE` | `/api/inventory/<public_id>` | Delete an inventory item |
+| `POST` | `/api/inventory/<public_id>/restock` | Restock an item by its `restock_amount` |
+| `POST` | `/api/inventory/<public_id>/decrement` | Decrement the quantity of an item |
+
+### Query Parameters — `GET /api/inventory`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `product_id` | string | Filter by product ID |
+| `condition` | string | Filter by condition (`NEW`, `OPEN_BOX`, `USED`) |
+| `restock` | boolean | `true` returns only items where `quantity <= restock_level` |
 
 ### Create an Inventory Item
 
-**`POST /inventory`**
+**`POST /api/inventory`**
 
 Request body (`application/json`):
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `product_id` | string | yes | Product identifier |
-| `quantity` | integer | no | Stock count (default: 0, must be >= 0) |
-| `restock_level` | integer | yes | Threshold that triggers a restock |
-| `restock_amount` | integer | yes | How many units to reorder |
+| `product_id` | string | yes | Product identifier (must not be empty) |
 | `condition` | string | yes | One of: `NEW`, `OPEN_BOX`, `USED` |
+| `quantity` | integer | no | Stock count (default: `0`, must be `>= 0`) |
+| `restock_level` | integer | yes | Quantity threshold that triggers a restock |
+| `restock_amount` | integer | yes | Number of units to add when restocking |
 
 Example:
 
@@ -102,54 +188,93 @@ Example:
 }
 ```
 
-Returns `201 Created` with the created item. Returns `409 Conflict` if an item with the same `product_id` and `condition` already exists.
+Returns `201 Created` with the created item (including its `public_id` UUID). Returns `409 Conflict` if an item with the same `product_id` and `condition` already exists.
 
 ### Update an Inventory Item
 
-**`PUT /inventory/<public_id>`**
+**`PUT /api/inventory/<public_id>`**
 
-Send a JSON body with the fields to update. All fields from the create payload are accepted.
+Send a JSON body with any fields from the create payload. All fields are accepted.
 
 Returns `200 OK` with the updated item, or `404 Not Found`.
 
 ### Delete an Inventory Item
 
-**`DELETE /inventory/<public_id>`**
+**`DELETE /api/inventory/<public_id>`**
 
-Returns `204 No Content`. This operation is idempotent — deleting a non-existent item still returns 204.
+Returns `204 No Content`. Idempotent — deleting a non-existent item also returns `204`.
+
+### Restock an Inventory Item
+
+**`POST /api/inventory/<public_id>/restock`**
+
+Increases `quantity` by the item's `restock_amount`. No request body required.
+
+Returns `200 OK` with the updated item, or `404 Not Found`.
+
+### Decrement an Inventory Item
+
+**`POST /api/inventory/<public_id>/decrement`**
+
+Request body (`application/json`):
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `amount` | integer | yes | Number of units to subtract (must be `>= 0` and `<= current quantity`) |
+
+Returns `200 OK` with the updated item. Returns `400 Bad Request` if `amount` exceeds the current quantity.
 
 ## Project Structure
 
 ```text
-.gitignore          - this will ignore vagrant and other metadata files
-.flaskenv           - Environment variables to configure Flask
-.gitattributes      - File to fix Windows CRLF issues
-.devcontainers/     - Folder with support for VSCode Remote Containers
-dot-env-example     - copy to .env to use environment variables
-pyproject.toml      - Poetry list of Python libraries required by your code
-
-service/                   - service python package
-├── __init__.py            - package initializer
-├── config.py              - configuration parameters
-├── models.py              - module with business models
-├── routes.py              - module with service routes
-└── common                 - common code package
-    ├── cli_commands.py    - Flask CLI commands (db-create, seed-db)
-    ├── error_handlers.py  - HTTP error handling code
-    ├── log_handlers.py    - logging setup code
-    └── status.py          - HTTP status constants
-
-tests/                     - test cases package
-├── __init__.py            - package initializer
-├── factories.py           - Factory for testing with fake objects
-├── test_cli_commands.py   - test suite for the CLI
-├── test_models.py         - test suite for business models
-└── test_routes.py         - test suite for service routes
+.devcontainer/              - VS Code Dev Container configuration
+.github/workflows/ci.yml    - GitHub Actions CI pipeline
+.tekton/                    - Tekton CD pipeline manifests
+  ├── pipeline.yaml         - inventory-cd-pipeline definition
+  ├── tasks.yaml            - custom tasks (pylint, pytest-env, deploy, behave)
+  ├── workspace.yaml        - PersistentVolumeClaim for the pipeline workspace
+  └── events/               - Tekton Triggers (EventListener, TriggerTemplate, etc.)
+k8s/                        - Kubernetes / OpenShift manifests
+  ├── deployment.yaml       - Deployment for the inventory service
+  ├── service.yaml          - ClusterIP Service
+  ├── route.yaml            - OpenShift Route (TLS edge termination)
+  ├── ingress.yaml          - Kubernetes Ingress
+  └── postgres/             - PostgreSQL StatefulSet, Service, PVC, Secret
+scripts/
+  └── deploy.sh             - Manual deploy script (applies manifests + triggers pipeline)
+service/                    - Flask application package
+  ├── __init__.py           - application factory
+  ├── config.py             - configuration parameters
+  ├── models.py             - InventoryItem model and Condition enum
+  ├── routes.py             - Flask-RESTX API routes
+  └── common/
+      ├── cli_commands.py   - Flask CLI commands (db-create, seed-db)
+      ├── error_handlers.py - HTTP error handlers
+      ├── log_handlers.py   - logging setup
+      └── status.py         - HTTP status constants
+features/                   - Behave BDD tests
+  ├── inventory.feature     - Gherkin feature file
+  ├── environment.py        - Behave environment hooks
+  └── steps/               - step definitions
+tests/                      - pytest unit tests
+  ├── factories.py          - Factory Boy model factories
+  ├── test_cli_commands.py  - CLI command tests
+  ├── test_models.py        - model tests
+  └── test_routes.py        - route/API tests
+Pipfile                     - Python dependencies (managed with pipenv)
+Makefile                    - developer task runner
+Procfile                    - honcho process file (used by `make run`)
+setup.cfg                   - pytest and coverage configuration
+wsgi.py                     - WSGI entry point
+dot-env-example             - example .env file
+.flaskenv                   - Flask environment defaults (FLASK_RUN_PORT=8080)
+.gitignore                  - ignored files
+.gitattributes              - line-ending normalization
 ```
 
 ## License
 
-Copyright (c) 2016, 2025 [John Rofrano](https://www.linkedin.com/in/JohnRofrano/). All rights reserved.
+Copyright (c) 2016, 2026 [John Rofrano](https://www.linkedin.com/in/JohnRofrano/). All rights reserved.
 
 Licensed under the Apache License. See [LICENSE](LICENSE)
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# This script is used for a manual deploy to production by triggering the tekton cd pipeline. Normally a deploy is triggered from the Webhook after a merge to the master branch. 
+set -euo pipefail
+
+# ── colours ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; YELLOW='\033[1;33m'; GREEN='\033[0;32m'
+CYAN='\033[0;36m'; BOLD='\033[1m'; RESET='\033[0m'
+
+info()    { echo -e "${CYAN}[INFO]${RESET}  $*"; }
+success() { echo -e "${GREEN}[OK]${RESET}    $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${RESET}  $*"; }
+die()     { echo -e "${RED}[ERROR]${RESET} $*" >&2; exit 1; }
+header()  { echo -e "\n${BOLD}$*${RESET}"; }
+
+# ── preflight checks ─────────────────────────────────────────────────────────
+header "=== Inventory Manual Deploy ==="
+
+command -v oc  &>/dev/null || die "'oc' not found. Install the OpenShift CLI and re-run."
+command -v tkn &>/dev/null || die "'tkn' not found. Install the Tekton CLI and re-run."
+
+info "Checking OpenShift authentication..."
+OC_USER=$(oc whoami 2>/dev/null) \
+  || die "Not logged in to OpenShift. Run 'oc login <cluster-url>' and re-run."
+OC_PROJECT=$(oc project -q 2>/dev/null) \
+  || die "Could not determine current project. Run 'oc project <name>' and re-run."
+
+success "Logged in as '${OC_USER}' — project '${OC_PROJECT}'"
+
+# ── apply manifests ───────────────────────────────────────────────────────────
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+header "── Applying PostgreSQL manifests ──"
+oc apply -f "${REPO_ROOT}/k8s/postgres/"
+success "PostgreSQL manifests applied."
+
+header "── Applying Tekton pipeline manifests ──"
+# Apply workspace, tasks, and pipeline (files directly in .tekton/)
+oc apply -f "${REPO_ROOT}/.tekton/workspace.yaml"
+oc apply -f "${REPO_ROOT}/.tekton/tasks.yaml"
+oc apply -f "${REPO_ROOT}/.tekton/pipeline.yaml"
+success "Tekton pipeline manifests applied."
+
+header "── Applying Tekton event listener / triggers ──"
+oc apply -f "${REPO_ROOT}/.tekton/events/"
+success "Event listener manifests applied."
+
+header "── Applying application routes ──"
+oc apply -f "${REPO_ROOT}/k8s/route.yaml"
+success "Routes applied."
+
+# ── wait for postgres to be ready ────────────────────────────────────────────
+header "── Waiting for PostgreSQL to be ready ──"
+info "Waiting up to 120 s for postgres StatefulSet rollout..."
+oc rollout status statefulset/postgres --timeout=120s \
+  && success "PostgreSQL is ready." \
+  || warn "PostgreSQL rollout did not finish in time — continuing anyway."
+
+# ── select git ref ───────────────────────────────────────────────────────────
+header "── Git ref ──"
+read -rp "Branch or commit SHA to deploy (press Enter to use default: master): " GIT_REF
+GIT_REF="${GIT_REF:-master}"
+info "Deploying ref: '${GIT_REF}'"
+
+# ── trigger pipeline ──────────────────────────────────────────────────────────
+header "── Triggering inventory-cd-pipeline ──"
+info "Starting pipeline run (logs will stream below)..."
+echo ""
+
+tkn pipeline start inventory-cd-pipeline \
+  --use-param-defaults \
+  -p GIT_REF="${GIT_REF}" \
+  -w name=pipeline-workspace,claimName=pipeline-pvc \
+  --showlog
+
+echo ""
+
+# ── post-run status ───────────────────────────────────────────────────────────
+header "── Pipeline run summary ──"
+LAST_RUN=$(tkn pipelinerun list --limit 1 -o name 2>/dev/null | head -1)
+
+if [[ -n "${LAST_RUN}" ]]; then
+  tkn pipelinerun describe "${LAST_RUN#*/}"
+  STATUS=$(tkn pipelinerun describe "${LAST_RUN#*/}" --output jsonpath='{.status.conditions[0].reason}' 2>/dev/null || true)
+  if [[ "${STATUS}" == "Succeeded" ]]; then
+    success "Pipeline completed successfully."
+  else
+    die "Pipeline finished with status: ${STATUS}. Check 'tkn pipelinerun logs ${LAST_RUN#*/}' for details."
+  fi
+else
+  warn "Could not retrieve pipeline run status."
+fi


### PR DESCRIPTION
- Updates README with up-to-date information about the service and the repo
- Add manual `./scripts/deploy.sh` script, which allows manual triggering of the CD pipeline, from a given branch (uses `master` as default). Includes a summary at the end of the run:
```

── Pipeline run summary ──
Name:              inventory-cd-pipeline-run-4mttl
Namespace:         jaqarrick-dev
Pipeline Ref:      inventory-cd-pipeline
Service Account:   pipeline
Labels:
 tekton.dev/pipeline=inventory-cd-pipeline
Annotations:
 results.tekton.dev/record=jaqarrick-dev/results/80a8c29f-18ea-416f-8469-21c3616d26fa/records/80a8c29f-18ea-416f-8469-21c3616d26fa
 results.tekton.dev/result=jaqarrick-dev/results/80a8c29f-18ea-416f-8469-21c3616d26fa
 results.tekton.dev/stored=true

🌡️  Status

STARTED         DURATION   STATUS
3 minutes ago   3m49s      Succeeded

⏱  Timeouts
 Pipeline:   1h0m0s

⚓ Params

 NAME        VALUE
 ∙ GIT_REF   master

📂 Workspaces

 NAME                   SUB PATH   WORKSPACE BINDING
 ∙ pipeline-workspace   ---        PersistentVolumeClaim (claimName=pipeline-pvc)

🗂  Taskruns

 NAME                                          TASK NAME   STARTED         DURATION   STATUS
 ∙ inventory-cd-pipeline-run-4mttl-bdd         bdd         1 minute ago    1m11s      Succeeded
 ∙ inventory-cd-pipeline-run-4mttl-deploy      deploy      1 minute ago    40s        Succeeded
 ∙ inventory-cd-pipeline-run-4mttl-buildah     buildah     2 minutes ago   53s        Succeeded
 ∙ inventory-cd-pipeline-run-4mttl-lint        lint        3 minutes ago   46s        Succeeded
 ∙ inventory-cd-pipeline-run-4mttl-test        test        3 minutes ago   40s        Succeeded
 ∙ inventory-cd-pipeline-run-4mttl-git-clone   git-clone   3 minutes ago   17s        Succeeded
[OK]    Pipeline completed successfully.
```
- Syntax fix in tekton tasks file.